### PR TITLE
Adiciona mais suporte para o open.mp, retorna valores como referência em apenas uma função

### DIFF
--- a/README.eng.md
+++ b/README.eng.md
@@ -30,10 +30,13 @@ With the `if`:
 ```pawn
 CMD:platform(playerid)
 {
-    if(IsPlayerAndroid(playerid))
+    new bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
+    //
+    if(isAndroid)
         SendClientMessage(playerid, 0xFFFFFFFF, "You are connected via the Mobile platform.");
     //
-    else if(!IsPlayerAndroid(playerid)) // Could be just else.
+    else if(!isAndroid) // Could be just else.
         SendClientMessage(playerid, 0xFFFFFFFF, "You are connected via the Computer platform.");
     //
     return true;
@@ -44,7 +47,8 @@ Without the `if`:
 ```pawn
 CMD:platform(playerid)
 {
-    new string[128];
+    new string[128], bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
     //
     format(string, sizeof(string), "You are connected via the %s platform.", IsPlayerAndroid(playerid) ? ("Mobile") : ("Computer"));
     SendClientMessage(playerid, 0xFFFFFFFF, string);
@@ -61,10 +65,13 @@ With the `if`:
 ```pawn
 CMD:aim(playerid)
 {
-    if(PlayerHasAutoAim(playerid))
+    new bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
+    //
+    if(haveAutoaim)
         SendClientMessage(playerid, 0xFFFFFFFF, "Your auto-aim is Enabled.");
     //
-    else if(!PlayerHasAutoAim(playerid)) // Could be just else.
+    else if(!haveAutoaim) // Could be just else.
         SendClientMessage(playerid, 0xFFFFFFFF, "Your auto-aim is Disabled.");
     //
     return true;
@@ -75,9 +82,10 @@ Without the `if`:
 ```pawn
 CMD:aim(playerid)
 {
-    new string[128];
+    new string[128], bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
     //
-    format(string, sizeof(string), "Your auto-aim is %s.", PlayerHasAutoAim(playerid) ? ("Enabled") : ("Disabled"));
+    format(string, sizeof(string), "Your auto-aim is %s.", haveAutoaim ? ("Enabled") : ("Disabled"));
     SendClientMessage(playerid, 0xFFFFFFFF, string);
     //
     return true;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Include VerificacaoPlataforma SA:MP
 
-Este Ã© um include que tem a funÃ§Ã£o de verificar se o jogador estÃ¡ usando um `mobile` ou um `computador`. Leia as categorias abaixo para se manter informado.
+Este é um include que tem a função de verificar se o jogador está usando um `mobile` ou um `computador`. Leia as categorias abaixo para se manter informado.
 
 English > [README](https://github.com/ocalasans/Verificacao-Plataforma/blob/main/README.eng.md).
 
@@ -8,34 +8,37 @@ English > [README](https://github.com/ocalasans/Verificacao-Plataforma/blob/main
 
 ### Como instalar?
 
-VocÃª deve fazer o download do include. Depois de tÃª-lo feito, vocÃª deverÃ¡ colocar o include na pasta (pawno > include). ApÃ³s ter feito isso, abra o arquivo pwn do seu Gamemode e coloque o seguinte cÃ³digo abaixo dos seus outros includes:
+Você deve fazer o download do include. Depois de tê-lo feito, você deverá colocar o include na pasta (pawno > include). Após ter feito isso, abra o arquivo pwn do seu Gamemode e coloque o seguinte código abaixo dos seus outros includes:
 ```pawn
 #include <VerificacaoPlataforma>
 ```
 
 -----------------------
 
-### Include necessÃ¡ria
+### Include necessária
 
 * [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet).
 
 > [!WARNING]
-> Se o usuÃ¡rio nÃ£o tiver ativado a biblioteca [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet), receberÃ¡ um erro de nÃºmero `111`.
+> Se o usuário não tiver ativado a biblioteca [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet), receberá um erro de número `111`.
 
 -----------------------
 
 ### Como funciona?
 
-Assim que o jogador se conecta ao servidor, o include automaticamente verifica em qual plataforma ele estÃ¡, seja `mobile` ou `computador`, com a assistÃªncia do [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet). Para conferir a plataforma do jogador, basta utilizar a funÃ§Ã£o booleana `IsPlayerAndroid`. Abaixo, estÃ£o alguns exemplos:
+Assim que o jogador se conecta ao servidor, o include automaticamente verifica em qual plataforma ele está, seja `mobile` ou `computador`, com a assistência do [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet). Para conferir a plataforma do jogador, basta utilizar a função booleana `IsPlayerAndroid`. Abaixo, estão alguns exemplos:
 
 Com o `if`
 ```pawn
 CMD:plataforma(playerid)
 {
-    if(IsPlayerAndroid(playerid))
+    new bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
+    //
+    if(isAndroid)
         SendClientMessage(playerid, 0xFFFFFFFF, "Voce esta conectado pela plataforma Mobile.");
     //
-    else if(!IsPlayerAndroid(playerid)) // Pode ser somente else.
+    else if(!isAndroid) // Pode ser somente else.
         SendClientMessage(playerid, 0xFFFFFFFF, "Voce esta conectado pela plataforma Computador.");
     //
     return true;
@@ -46,9 +49,10 @@ Sem o `if`
 ```pawn
 CMD:plataforma(playerid)
 {
-    new string[128];
+    new string[128], bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
     //
-    format(string, sizeof(string), "Voce esta conectado pela plataforma %s.", IsPlayerAndroid(playerid) ? ("Mobile") : ("Computador"));
+    format(string, sizeof(string), "Voce esta conectado pela plataforma %s.", isAndroid ? ("Mobile") : ("Computador"));
     SendClientMessage(playerid, 0xFFFFFFFF, string);
     //
     return true;
@@ -57,16 +61,19 @@ CMD:plataforma(playerid)
 
 -----------------------
 
-Este include tambÃ©m possui uma funÃ§Ã£o chamada `PlayerHasAutoAim`. Essa funÃ§Ã£o consiste em verificar se o jogador estÃ¡ com mira automÃ¡tica ou se estÃ¡ sem a mira automÃ¡tica, conhecida como `LockOn`. Abaixo, estÃ£o alguns exemplos:
+Este include também possui uma função chamada `PlayerHasAutoAim`. Essa função consiste em verificar se o jogador está com mira automática ou se está sem a mira automática, conhecida como `LockOn`. Abaixo, estão alguns exemplos:
 
 Com o `if`
 ```pawn
 CMD:mira(playerid)
 {
-    if(PlayerHasAutoAim(playerid))
+    new bool:isAndroid, bool:haveAutoaim;
+    GetPlayerPlataformInfo(playerid, isAndroid, haveAutoaim);
+    //
+    if(haveAutoaim)
         SendClientMessage(playerid, 0xFFFFFFFF, "Sua mira automatica esta Ativada.");
     //
-    else if(!PlayerHasAutoAim(playerid)) // Pode ser somente else.
+    else if(!haveAutoaim) // Pode ser somente else.
         SendClientMessage(playerid, 0xFFFFFFFF, "Sua mira automatica esta Desativada.");
     //
     return true;
@@ -77,9 +84,9 @@ Sem o `if`
 ```pawn
 CMD:mira(playerid)
 {
-    new string[128];
+    new string[128], bool:isAndroid, bool:haveAutoaim;
     //
-    format(string, sizeof(string), "Sua mira automatica esta %s.", PlayerHasAutoAim(playerid) ? ("Ativada") : ("Desativada"));
+    format(string, sizeof(string), "Sua mira automatica esta %s.", haveAutoaim(playerid) ? ("Ativada") : ("Desativada"));
     SendClientMessage(playerid, 0xFFFFFFFF, string);
     //
     return true;
@@ -88,9 +95,9 @@ CMD:mira(playerid)
 
 -----------------------
 
-### InformaÃ§Ãµes de contato
+### Informações de contato
 
 Instagram: [ocalasans](https://instagram.com/ocalasans)   
 YouTube: [Calasans](https://www.youtube.com/@ocalasans)   
 Discord: ocalasans   
-Comunidade: [SA:MP Programming CommunityÂ©](https://abre.ai/samp-spc)
+Comunidade: [SA:MP Programming Community©](https://abre.ai/samp-spc)

--- a/VerificacaoPlataforma.inc
+++ b/VerificacaoPlataforma.inc
@@ -23,15 +23,15 @@
 #endif
 #define _verificacao_plataform_included
 //
-#if !defined _samp_included
-    #error "A biblioteca `a_samp` nao foi ativada. Por favor, ative-a no inicio do seu Gamemode, Ex: `#include <a_samp>`"
+#if !defined _samp_included || !defined _INC_open_mp
+    #error "A biblioteca `a_samp` ou `open.mp` nao foi ativada. Por favor, ative-a no inicio do seu Gamemode, Ex: `#include <a_samp>`"
 #endif
 //
 #if !defined PAWNRAKNET_INC_
     #error "A biblioteca `Pawn.RakNet` nao foi ativada. Por favor, ative-a no seu Gamemode, Ex: `#include <Pawn.RakNet>`"
 #endif
 //
-#if !defined gpci
+#if !defined gpci && !defined _INC_open_mp
     native gpci(playerid, buffer[], size = sizeof(buffer));
 #endif
 
@@ -118,7 +118,13 @@ public OnPlayerConnect(playerid)
 {
     new VPI_string[64];
     //
+    #if defined gpci && !defined _INC_open_mp
     gpci(playerid, VPI_string, sizeof VPI_string);
+    #endif
+    //
+    #if defined _INC_open_mp
+    GPCI(playerid, VPI_string, sizeof VPI_string);
+    #endif
     //
     if(!strcmp(VPI_string, VPI_chave_android))
         VPI_player_android[playerid][VPI_Android] = true;
@@ -179,11 +185,10 @@ $$ |   \$$$$$$  |$$ |  $$ |\$$$$$$$\ \$$$$$$  |\$$$$$$$\ $$$$$$$  |      $$ |   
 \__|    \______/ \__|  \__| \_______| \______/  \_______|\_______/       \__|      \__|    \______/ \__|  \__| \_______|   \____/ \__| \______/ \__|  \__|\_______/ 
 */
 
-stock bool:IsPlayerAndroid(playerid)
-    return VPI_player_android[playerid][VPI_Android];
-//
-stock bool:PlayerHasAutoAim(playerid)
-    return VPI_player_android[playerid][VPI_Mira_Automatica];
+stock GetPlayerPlataformInfo(playerid, &bool:mobile, &bool:aimlock) {
+    mobile = VPI_player_android[playerid][VPI_Android];
+    aimlock = VPI_player_android[playerid][VPI_Mira_Automatica];
+}
 
 /*
  $$$$$$\    $$\     $$\                                 $$$$$$$\             $$$$$$\  $$\           $$\   $$\     $$\                               


### PR DESCRIPTION
Peço que considere este PR, pois acredito que retornar os valores como referência em apenas uma função, GetPlayerPlataformInfo, é mais consistente do que usar duas funções, cujas sintaxes são inconsistentes. Além disso, neste PR, adicionei mais suporte ao open.mp, adicionando suporte à função GPCI (em maiúsculo, pois no open.mp ela é definida dessa forma).